### PR TITLE
fix: update ruby version to `3.0`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6
+FROM ruby:3.0
 
 LABEL "repository"="https://github.com/g4s8/xcop-action"
 LABEL "maintainer"="Kirill Che."


### PR DESCRIPTION
I've checked locally and it seems that Docker image is created successfully with Ruby version `3.0`.

Closes: #4 