### PR TITLE
#3 Added multiple files support

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -3,11 +3,10 @@
 set -euo pipefail
 
 license=$1
-globs=$(echo $2 | tr "," "\n")
 
 cd ${GITHUB_WORKSPACE}
 
-for glob in $globs
+for glob in $2
 do
     xcop --license="${license}" $(find . -path "${glob}")
 done

--- a/entry.sh
+++ b/entry.sh
@@ -3,7 +3,11 @@
 set -euo pipefail
 
 license=$1
-glob=$2
+globs=$(echo $2 | tr "," "\n")
 
 cd ${GITHUB_WORKSPACE}
-xcop --license="${license}" $(find . -path "${glob}")
+
+for glob in $globs
+do
+    xcop --license="${license}" $(find . -path "${glob}")
+done


### PR DESCRIPTION
I suggest to use multiple globs separated by `,` (comma) via `files` field.
So to use it we would need something like this:
```yaml
- uses: g4s8/xcop-action@master
  with:
    license: MY_LICENSE.txt
    files: "src/*.xml,src/*.xsl"
```
@g4s8 WDYT?